### PR TITLE
fix(django): return None instead of empty string from WilcoBundleFinder.find()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Django finders**: `WilcoBundleFinder.find()` now returns `None` instead of `""` when no file matches, fixing Django's `finders.find()` aggregation and whitenoise compatibility (#16)
+
 ## [0.5.1] - 2026-03-26
 
 ### Fixed

--- a/src/wilco/bridges/django/finders.py
+++ b/src/wilco/bridges/django/finders.py
@@ -52,7 +52,7 @@ class WilcoBundleFinder(BaseFinder):
         if find_all is not None:
             all = find_all
         if not self._build_path or not path.startswith("wilco/"):
-            return [] if all else ""
+            return [] if all else None
 
         # Strip the wilco/ prefix to get the path relative to build dir
         relative = path[len("wilco/") :]
@@ -60,13 +60,13 @@ class WilcoBundleFinder(BaseFinder):
 
         # Prevent path traversal outside the build directory
         if not full_path.is_relative_to(self._resolved_build_path):
-            return [] if all else ""
+            return [] if all else None
 
         if full_path.is_file():
             matched = str(full_path)
             return [matched] if all else matched
 
-        return [] if all else ""
+        return [] if all else None
 
     def list(self, ignore_patterns):
         """List all files in the build directory."""

--- a/tests/test_django_finders.py
+++ b/tests/test_django_finders.py
@@ -54,18 +54,18 @@ class TestWilcoBundleFinder:
         assert result != ""
         assert "manifest.json" in result
 
-    def test_find_returns_empty_for_missing_file(self, temp_dir: Path) -> None:
-        """find() should return empty for non-existent files."""
+    def test_find_returns_none_for_missing_file(self, temp_dir: Path) -> None:
+        """find() should return None for non-existent files (not empty string)."""
         build_dir = temp_dir / "build"
         build_dir.mkdir()
 
         finder = self._make_finder(build_dir)
         result = finder.find("wilco/nonexistent.js")
 
-        assert result == ""
+        assert result is None
 
-    def test_find_returns_empty_for_non_wilco_prefix(self, temp_dir: Path) -> None:
-        """find() should return empty for paths not starting with wilco/."""
+    def test_find_returns_none_for_non_wilco_prefix(self, temp_dir: Path) -> None:
+        """find() should return None for paths not starting with wilco/."""
         build_dir = temp_dir / "build"
         build_dir.mkdir()
         (build_dir / "manifest.json").write_text("{}")
@@ -73,7 +73,7 @@ class TestWilcoBundleFinder:
         finder = self._make_finder(build_dir)
         result = finder.find("other/manifest.json")
 
-        assert result == ""
+        assert result is None
 
     def test_find_rejects_path_traversal(self, temp_dir: Path) -> None:
         """find() must reject paths that escape the build directory."""
@@ -87,7 +87,7 @@ class TestWilcoBundleFinder:
         finder = self._make_finder(build_dir)
         result = finder.find("wilco/../secret.txt")
 
-        assert result == ""
+        assert result is None
 
     def test_find_rejects_deep_traversal(self, temp_dir: Path) -> None:
         """find() must reject deeply nested traversal attempts."""
@@ -97,7 +97,31 @@ class TestWilcoBundleFinder:
         finder = self._make_finder(build_dir)
         result = finder.find("wilco/../../../etc/passwd")
 
-        assert result == ""
+        assert result is None
+
+    def test_find_no_match_does_not_pollute_django_finders(self, temp_dir: Path) -> None:
+        """Django finders.find() must not return [''] due to WilcoBundleFinder.
+
+        Regression test for #16: when all=False, returning '' instead of None
+        causes Django's finders.find() to wrap it into [''] and return that
+        instead of None.
+        """
+        build_dir = temp_dir / "build"
+        build_dir.mkdir()
+
+        finder = self._make_finder(build_dir)
+        result = finder.find("wilco/nonexistent.js")
+
+        # Must be None (falsy AND not wrappable into a truthy list)
+        assert result is None
+        # Simulate Django's finders.find() wrapping logic
+        if not isinstance(result, (list, tuple)):
+            wrapped = [result]
+        else:
+            wrapped = result
+        # [None] is truthy, but Django checks `not all and result` first,
+        # which short-circuits when result is None (falsy)
+        assert not result  # falsy, so Django skips wrapping entirely
 
     def test_find_with_all_returns_list(self, temp_dir: Path) -> None:
         """find(all=True) should return a list."""

--- a/tests/test_django_finders.py
+++ b/tests/test_django_finders.py
@@ -55,7 +55,11 @@ class TestWilcoBundleFinder:
         assert "manifest.json" in result
 
     def test_find_returns_none_for_missing_file(self, temp_dir: Path) -> None:
-        """find() should return None for non-existent files (not empty string)."""
+        """find() should return None for non-existent files (not empty string).
+
+        Regression test for #16: returning '' caused Django's finders.find()
+        to wrap it into [''], breaking downstream consumers like whitenoise.
+        """
         build_dir = temp_dir / "build"
         build_dir.mkdir()
 
@@ -98,30 +102,6 @@ class TestWilcoBundleFinder:
         result = finder.find("wilco/../../../etc/passwd")
 
         assert result is None
-
-    def test_find_no_match_does_not_pollute_django_finders(self, temp_dir: Path) -> None:
-        """Django finders.find() must not return [''] due to WilcoBundleFinder.
-
-        Regression test for #16: when all=False, returning '' instead of None
-        causes Django's finders.find() to wrap it into [''] and return that
-        instead of None.
-        """
-        build_dir = temp_dir / "build"
-        build_dir.mkdir()
-
-        finder = self._make_finder(build_dir)
-        result = finder.find("wilco/nonexistent.js")
-
-        # Must be None (falsy AND not wrappable into a truthy list)
-        assert result is None
-        # Simulate Django's finders.find() wrapping logic
-        if not isinstance(result, (list, tuple)):
-            wrapped = [result]
-        else:
-            wrapped = result
-        # [None] is truthy, but Django checks `not all and result` first,
-        # which short-circuits when result is None (falsy)
-        assert not result  # falsy, so Django skips wrapping entirely
 
     def test_find_with_all_returns_list(self, temp_dir: Path) -> None:
         """find(all=True) should return a list."""


### PR DESCRIPTION
## Summary

- `WilcoBundleFinder.find(path, all=False)` returned `""` instead of `None` when no file matched, breaking Django's `finders.find()` aggregation
- Django wraps `""` into `[""]` (truthy), causing downstream consumers like whitenoise to receive a list instead of `None`
- Now returns `None`, matching Django's built-in finder convention

Closes #16

## Changes

- `src/wilco/bridges/django/finders.py`: changed `return [] if all else ""` to `return [] if all else None` (3 occurrences)
- `tests/test_django_finders.py`: updated 4 test assertions from `== ""` to `is None`, added regression context in docstring
- `CHANGELOG.md`: added entry under Unreleased

## Test plan

- [x] All 240 backend tests pass
- [x] All 124 frontend tests pass
- [x] Finder tests verify `None` is returned for: missing files, non-wilco prefixes, path traversal attempts